### PR TITLE
Add tools to import results to GH project

### DIFF
--- a/get-item-id.sh
+++ b/get-item-id.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# The first argument is the issue url
+issue=$1
+if [ -z "$issue" ]; then
+  echo "Usage: $0 <issue_url>"
+  exit 1
+fi
+
+# Get the Project Item ID from the Content URL
+
+gh api graphql -f query='
+query ($url: URI!) {
+  resource(url: $url) {
+    ... on Issue {
+      projectItems(first: 10) {
+        nodes {
+          id
+          project {
+            number
+          }
+        }
+      }
+    }
+  }
+}
+' -f url="${issue}" |
+  jq -r '.data.resource.projectItems.nodes[] | select(.project.number == 475) | .id'

--- a/import.sh
+++ b/import.sh
@@ -1,0 +1,35 @@
+# This script takes a csv file as input.
+# The expected format is:
+# Title,URL,Comment Count,Unique Commenters,Upvotes,Engagement Score,Years Opened,Frustration Score
+# The script will take the first 50 items and add them to the Web Squad .NET 10 Planning project.
+
+# The first argument is the csv file
+csv=$1
+if [ -z "$csv" ]; then
+  echo "Usage: $0 <csv_file>"
+  exit 1
+fi
+projectId=PVT_kwDOAIt-yc4ArJar
+fieldId=PVTF_lADOAIt-yc4ArJarzgnNyeQ      # F Score field ID
+
+awk -F "," '{print $2,$8}' $csv | grep -e "^https" | while read url frustration; do
+  # Trim the ^M character from the frustration score
+  frustration=$(echo $frustration | tr -d '\r')
+  # drop the decimal
+  if (( ${frustration%.*} >= 10 )); then
+    echo "Adding $url to the Web Squad .NET 10 Planning project"
+    gh project item-add 475 --owner dotnet --url ${url}
+    # Get the Project Item ID from the Content URL
+    itemId=$(./get-item-id.sh $url)
+    # gh command is broken for float values. https://github.com/cli/cli/issues/10342
+    #gh project item-edit --project-id ${projectId} --id ${itemId} --field-id ${fscoreFieldId} --number ${frustration}
+    gh api graphql -f query='
+      mutation ($itemId: ID!) {
+        updateProjectV2ItemFieldValue(input: {projectId: "'$projectId'", itemId: $itemId, fieldId: "'$fieldId'", value: {number: '$frustration'}}) {
+          projectV2Item {
+            id
+          }
+        }
+      }' -f itemId=${itemId}
+  fi
+done


### PR DESCRIPTION
This PR adds two scripts that will take a comma-separated file exported from an xlsx created by the analysis tools and import all issues with a frustration score > 10 into the "Web Squad .NET 10 Planning" GitHub project.

The scripts are currently hardcoded to this specific project and its configuration to keep them simple, but it should be easy to make them more flexible if needed in the future.